### PR TITLE
Add option to collect cpu usage from processes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,6 +33,7 @@ function buildProcessTree(processList: IProcessInfo[], rootPid: number): IProces
     pid: rootProcess.pid,
     name: rootProcess.name,
     memory: rootProcess.memory,
+    cpu: rootProcess.pcpu,
     children: childIndexes.map(c => buildProcessTree(processList, c.pid))
   };
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,23 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 
 const native = require('../build/Release/windows_process_tree.node');
-import { IProcessTreeNode } from 'windows-process-tree';
+import { IProcessInfo, IProcessTreeNode, IProcessCpuInfo } from 'windows-process-tree';
 
 export enum ProcessDataFlag {
     None = 0,
     Memory = 1
   }
 
-interface IProcessInfo {
-    pid: number;
-    ppid: number;
-    name: string;
-    memory?: number;
-}
-
+// requestInProgress is used for any function that uses CreateToolhelp32Snapshot, as multiple calls
+// to this cannot be done at the same time.
 let requestInProgress = false;
-const requestQueue = [];
+let cpuUsageRequestInProgress = false;
 
+const requestQueue = {
+  getProcessCpuUsage: [],
+  getProcessList: [],
+  getProcessTree: []
+};
+
+/**
+ * Filters a list of processes to rootPid and its descendents and creates a tree
+ * @param processList The list of processes
+ * @param rootPid The process to use as the root
+ */
 function buildProcessTree(processList: IProcessInfo[], rootPid: number): IProcessTreeNode {
   const rootIndex = processList.findIndex(v => v.pid === rootPid);
   if (rootIndex === -1) {
@@ -33,14 +39,35 @@ function buildProcessTree(processList: IProcessInfo[], rootPid: number): IProces
     pid: rootProcess.pid,
     name: rootProcess.name,
     memory: rootProcess.memory,
-    cpu: rootProcess.pcpu,
     children: childIndexes.map(c => buildProcessTree(processList, c.pid))
   };
 }
 
-export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode) => void, flags?: ProcessDataFlag): void {
+/**
+ * Filters processList to contain the process with rootPid and all of its descendants
+ * @param rootPid The root pid
+ * @param processList The list of all processes
+ */
+function filterProcessList(rootPid: number, processList: IProcessInfo[]): IProcessInfo[] {
+  const rootIndex = processList.findIndex(v => v.pid === rootPid);
+  if (rootIndex === -1) {
+    return undefined;
+  }
+
+  const rootProcess = processList[rootIndex];
+  const childIndexes = processList.filter(v => v.ppid === rootPid);
+  return childIndexes.map(c => filterProcessList(c.pid, processList)).reduce((prev, current) => prev.concat(current), [rootProcess]);
+}
+
+/**
+ * Returns a list of processes containing the rootPid process and all of its descendants
+ * @param rootPid The pid of the process of interest
+ * @param callback The callback to use with the returned set of processes
+ * @param flags The flags for what process data should be included
+ */
+export function getProcessList(rootPid: number, callback: (processList: IProcessInfo[]) => void, flags?: ProcessDataFlag): void {
   // Push the request to the queue
-  requestQueue.push({
+  requestQueue.getProcessList.push({
     callback: callback,
     rootPid: rootPid
   });
@@ -52,10 +79,62 @@ export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNod
   if (!requestInProgress) {
     requestInProgress = true;
     native.getProcessList((processList) => {
-      requestQueue.forEach(r => {
+      requestQueue.getProcessList.forEach(r => {
+        r.callback(filterProcessList(r.rootPid, processList));
+      });
+      requestQueue.getProcessList.length = 0;
+      requestInProgress = false;
+    }, flags || 0);
+  }
+}
+
+/**
+ * Returns the list of processes annotated with cpu usage information
+ * @param processList The list of processes
+ * @param callback The callback to use with the returned list of processes
+ */
+export function getProcessCpuUsage(processList: IProcessInfo[], callback: (tree: IProcessCpuInfo[]) => void): void {
+    // Push the request to the queue
+    requestQueue.getProcessCpuUsage.push({
+      callback: callback
+    });
+
+    if (!cpuUsageRequestInProgress) {
+      cpuUsageRequestInProgress = true;
+      native.getProcessCpuUsage(processList, (processListWithCpu) => {
+        requestQueue.getProcessCpuUsage.forEach(r => {
+          r.callback(processListWithCpu);
+        });
+        requestQueue.getProcessCpuUsage.length = 0;
+        cpuUsageRequestInProgress = false;
+      });
+    }
+}
+
+/**
+ * Returns a tree of processes with rootPid as the root
+ * @param rootPid The pid of the process that will be the root of the tree
+ * @param callback The callback to use with the returned list of processes
+ * @param flags Flags indicating what process data should be written on each node
+ */
+export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode) => void, flags?: ProcessDataFlag): void {
+  // Push the request to the queue
+  requestQueue.getProcessTree.push({
+    callback: callback,
+    rootPid: rootPid
+  });
+
+  // Only make a new request if there is not currently a request in progress.
+  // This prevents too many requests from being made, there is also a crash that
+  // can occur when performing multiple calls to CreateToolhelp32Snapshot at
+  // once.
+  if (!requestInProgress) {
+    requestInProgress = true;
+    native.getProcessList((processList) => {
+      requestQueue.getProcessTree.forEach(r => {
         r.callback(buildProcessTree(processList, r.rootPid));
       });
-      requestQueue.length = 0;
+      requestQueue.getProcessTree.length = 0;
       requestInProgress = false;
     }, flags || 0);
   }

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -103,7 +103,7 @@ describe('getProcessList', () => {
     }, ProcessDataFlag.Memory);
   });
 
-  it('should return a tree containing this process\'s child processes', done => {
+  it('should return a list containing this process\'s child processes', done => {
     cps.push(child_process.spawn('cmd.exe'));
     pollUntil(() => {
       return new Promise((resolve) => {

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -68,6 +68,17 @@ describe('getProcessList', () => {
       }, ProcessDataFlag.Memory);
     }, ProcessDataFlag.None);
   });
+
+  it('should return cpu information only when the flag is set', (done) => {
+    native.getProcessList((list) => {
+      assert.equal(list.every(p => p.pcpu === undefined), true);
+
+      native.getProcessList((list) => {
+        assert.equal(list.some(p => p.pcpu > 0), true);
+        done();
+      }, 2);
+    }, 0);
+  });
 });
 
 describe('getProcessTree', () => {
@@ -101,6 +112,16 @@ describe('getProcessTree', () => {
       assert.equal(tree.children.length, 0);
       done();
     }, ProcessDataFlag.Memory);
+  });
+
+  it('should return a tree containing this process\'s cpu if the flag is set', done => {
+    getProcessTree(process.pid, (tree) => {
+      assert.equal(tree.name, 'node.exe');
+      assert.equal(tree.pid, process.pid);
+      assert.notEqual(tree.cpu, undefined);
+      assert.equal(tree.children.length, 0);
+      done();
+    }, 2);
   });
 
   it('should return a tree containing this process\'s child processes', done => {

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -118,14 +118,7 @@ describe('getProcessList', () => {
 describe('getProcessCpuUsage', () => {
 
   it('should get process cpu usage', (done) => {
-    getProcessList(process.pid, (list) => {
-      assert.equal(list.length, 1);
-      assert.equal(list[0].name, 'node.exe');
-      assert.equal(list[0].pid, process.pid);
-      assert.equal(list[0].memory, undefined);
-      assert.equal((list[0] as any).cpu, undefined);
-
-      getProcessCpuUsage(list, (annotatedList) => {
+      getProcessCpuUsage([{ pid: process.pid, ppid: process.ppid, name: 'node.exe' }], (annotatedList) => {
         assert.equal(annotatedList.length, 1);
         assert.equal(annotatedList[0].name, 'node.exe');
         assert.equal(annotatedList[0].pid, process.pid);
@@ -133,10 +126,22 @@ describe('getProcessCpuUsage', () => {
         assert.equal(typeof annotatedList[0].cpu, 'number');
         assert.equal(0 <= annotatedList[0].cpu && annotatedList[0].cpu <= 100, true);
         done();
-      });
     });
   });
 
+  it('should handle multiple calls gracefully', function (done: MochaDone): void {
+    this.timeout(3000);
+
+    let counter = 0;
+    const callback = (list) => {
+      assert.notEqual(list.find(p => p.pid === process.pid), undefined);
+      if (++counter === 2) {
+        done();
+      }
+    };
+    getProcessCpuUsage([{ pid: process.pid, ppid: process.ppid, name: 'node.exe' }], callback);
+    getProcessCpuUsage([{ pid: process.pid, ppid: process.ppid, name: 'node.exe' }], callback);
+  });
 });
 
 describe('getProcessTree', () => {

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -32,9 +32,65 @@ void GetProcessList(const Nan::FunctionCallbackInfo<v8::Value>& args) {
   Nan::AsyncQueueWorker(worker);
 }
 
+void GetProcessCpuUsage(const Nan::FunctionCallbackInfo<v8::Value>& args) {
+  if (args.Length() < 2) {
+      Nan::ThrowTypeError("GetProcessCpuUsage expects two arguments.");
+      return;
+  }
+
+  if (!args[0]->IsArray()) {
+    Nan::ThrowTypeError("The first argument of GetProcessCpuUsage, callback, must be an array.");
+    return;
+  }
+
+  if (!args[1]->IsFunction()) {
+    Nan::ThrowTypeError("The second argument of GetProcessCpuUsage, flags, must be a function.");
+    return;
+  }
+
+  // Read the ProcessTreeNode JS object
+  v8::Local<v8::Array> processes = v8::Local<v8::Array>::Cast(args[0]);
+  uint32_t count = processes->Length();
+  Cpu* cpu_info = new Cpu[count];
+
+  // Read pid from each array and populate data structure to calculate CPU, take first sample of counters
+  for (uint32_t i = 0; i < count; i++) {
+    v8::Local<v8::Object> process = processes->Get(Nan::New<v8::Integer>(i))->ToObject();
+    DWORD pid = (DWORD)(process->Get(Nan::New("pid").ToLocalChecked()))->NumberValue();
+    cpu_info[i].pid = pid;
+    GetCpuUsage(cpu_info, &i, true);
+  }
+
+  // Sleep for one second
+  Sleep(1000);
+
+
+  // Sample counters again and complete CPU usage calculation
+  for (uint32_t i = 0; i < count; i++) {
+    GetCpuUsage(cpu_info, &i, false);
+  }
+
+  Nan::Callback *callback = new Nan::Callback(v8::Local<v8::Function>::Cast(args[1]));
+
+  v8::Local<v8::Array> result = Nan::New<v8::Array>(count);
+  for (uint32_t i = 0; i < count; i++) {
+    // Should this be cloned?
+    v8::Local<v8::Object> object = processes->Get(Nan::New<v8::Integer>(i))->ToObject();
+    Nan::Set(object, Nan::New<v8::String>("cpu").ToLocalChecked(),
+              Nan::New<v8::Number>(cpu_info[i].cpu));
+
+    Nan::Set(result, i, Nan::New<v8::Value>(object));
+  }
+
+  v8::Local<v8::Value> argv[] = { result };
+  callback->Call(1, argv);
+}
+
 void Init(v8::Local<v8::Object> exports) {
   exports->Set(Nan::New("getProcessList").ToLocalChecked(),
                Nan::New<v8::FunctionTemplate>(GetProcessList)->GetFunction());
+  exports->Set(Nan::New("getProcessCpuUsage").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(GetProcessCpuUsage)->GetFunction());
 }
 
 NODE_MODULE(hello, Init)

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -6,6 +6,7 @@
 #include <nan.h>
 #include "process.h"
 #include "worker.h"
+#include <cmath>
 
 void GetProcessList(const Nan::FunctionCallbackInfo<v8::Value>& args) {
   ProcessInfo process_info[1024];
@@ -64,7 +65,6 @@ void GetProcessCpuUsage(const Nan::FunctionCallbackInfo<v8::Value>& args) {
   // Sleep for one second
   Sleep(1000);
 
-
   // Sample counters again and complete CPU usage calculation
   for (uint32_t i = 0; i < count; i++) {
     GetCpuUsage(cpu_info, &i, false);
@@ -74,10 +74,12 @@ void GetProcessCpuUsage(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::Local<v8::Array> result = Nan::New<v8::Array>(count);
   for (uint32_t i = 0; i < count; i++) {
-    // Should this be cloned?
     v8::Local<v8::Object> object = processes->Get(Nan::New<v8::Integer>(i))->ToObject();
-    Nan::Set(object, Nan::New<v8::String>("cpu").ToLocalChecked(),
-              Nan::New<v8::Number>(cpu_info[i].cpu));
+
+    if (!std::isnan(cpu_info[i].cpu)) {
+      Nan::Set(object, Nan::New<v8::String>("cpu").ToLocalChecked(),
+                Nan::New<v8::Number>(cpu_info[i].cpu));
+    }
 
     Nan::Set(result, i, Nan::New<v8::Value>(object));
   }

--- a/src/process.cc
+++ b/src/process.cc
@@ -7,6 +7,7 @@
 
 #include <tlhelp32.h>
 #include <psapi.h>
+#include <limits>
 
 void GetRawProcessList(ProcessInfo process_info[1024], uint32_t* process_count, DWORD* process_data_flags) {
   *process_count = 0;
@@ -51,6 +52,10 @@ void GetProcessMemoryUsage(ProcessInfo process_info[1024], uint32_t* process_cou
   }
 }
 
+// Per documentation, it is not recommended to add or subtract values from the FILETIME
+// structure, or to cast it to ULARGE_INTEGER as this can cause alignment faults on 64-bit Windows.
+// Copy the high and low part to a ULARGE_INTEGER and peform arithmetic on that instead.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
 ULONGLONG GetTotalTime(const FILETIME* kernelTime, const FILETIME* userTime) {
   ULARGE_INTEGER kt, ut;
   kt.LowPart = (*kernelTime).dwLowDateTime;
@@ -76,15 +81,17 @@ void GetCpuUsage(Cpu* cpu_info, uint32_t* process_index, BOOL first_pass) {
   FILETIME sysIdleTime, sysKernelTime, sysUserTime;
   if (GetProcessTimes(hProcess, &creationTime, &exitTime, &kernelTime, &userTime)
     && GetSystemTimes(&sysIdleTime, &sysKernelTime, &sysUserTime)) {
-      if (first_pass) {
-        cpu_info[*process_index].initialProcRunTime = GetTotalTime(&kernelTime, &userTime);
-        cpu_info[*process_index].initialSystemTime = GetTotalTime(&sysKernelTime, &sysUserTime);
-      } else {
-        ULONGLONG endProcTime = GetTotalTime(&kernelTime, &userTime);
-        ULONGLONG endSysTime = GetTotalTime(&sysKernelTime, &sysUserTime);
+    if (first_pass) {
+      cpu_info[*process_index].initialProcRunTime = GetTotalTime(&kernelTime, &userTime);
+      cpu_info[*process_index].initialSystemTime = GetTotalTime(&sysKernelTime, &sysUserTime);
+    } else {
+      ULONGLONG endProcTime = GetTotalTime(&kernelTime, &userTime);
+      ULONGLONG endSysTime = GetTotalTime(&sysKernelTime, &sysUserTime);
 
-        cpu_info[*process_index].cpu = 100.0 * (endProcTime - cpu_info[*process_index].initialProcRunTime) / (endSysTime - cpu_info[*process_index].initialSystemTime);
-      }
+      cpu_info[*process_index].cpu = 100.0 * (endProcTime - cpu_info[*process_index].initialProcRunTime) / (endSysTime - cpu_info[*process_index].initialSystemTime);
+    }
+  } else {
+    cpu_info[*process_index].cpu = std::numeric_limits<double>::quiet_NaN();
   }
 
   CloseHandle(hProcess);

--- a/src/process.h
+++ b/src/process.h
@@ -9,20 +9,32 @@
 #include <nan.h>
 #include <windows.h>
 
+struct Cpu {
+  double pcpu;
+  ULONGLONG initialProcRunTime;
+  ULONGLONG initialSystemTime;
+};
+
 struct ProcessInfo {
   TCHAR name[MAX_PATH];
   DWORD pid;
   DWORD ppid;
   DWORD memory; // Reported in bytes
+  Cpu cpu;
 };
 
 enum ProcessDataFlags {
   NONE = 0,
-  MEMORY = 1
+  MEMORY = 1,
+  CPU = 2
 };
 
 void GetRawProcessList(ProcessInfo process_info[1024], uint32_t* process_count, DWORD* flags);
 
+void BuildProcessList(DWORD* pid, ProcessInfo process_info[1024], uint32_t* process_count, ProcessInfo matching_processes[1024], uint32_t* matching_process_count);
+
 void GetProcessMemoryUsage(ProcessInfo process_info[1024], uint32_t* process_count);
+
+void GetCpuUsage(ProcessInfo process_info[1024], uint32_t* process_count, BOOL first_run);
 
 #endif  // SRC_PROCESS_H_

--- a/src/process.h
+++ b/src/process.h
@@ -25,8 +25,7 @@ struct ProcessInfo {
 
 enum ProcessDataFlags {
   NONE = 0,
-  MEMORY = 1,
-  CPU = 2
+  MEMORY = 1
 };
 
 void GetRawProcessList(ProcessInfo process_info[1024], uint32_t* process_count, DWORD* flags);

--- a/src/process.h
+++ b/src/process.h
@@ -10,7 +10,8 @@
 #include <windows.h>
 
 struct Cpu {
-  double pcpu;
+  DWORD pid;
+  double cpu;
   ULONGLONG initialProcRunTime;
   ULONGLONG initialSystemTime;
 };
@@ -20,7 +21,6 @@ struct ProcessInfo {
   DWORD pid;
   DWORD ppid;
   DWORD memory; // Reported in bytes
-  Cpu cpu;
 };
 
 enum ProcessDataFlags {
@@ -31,10 +31,8 @@ enum ProcessDataFlags {
 
 void GetRawProcessList(ProcessInfo process_info[1024], uint32_t* process_count, DWORD* flags);
 
-void BuildProcessList(DWORD* pid, ProcessInfo process_info[1024], uint32_t* process_count, ProcessInfo matching_processes[1024], uint32_t* matching_process_count);
-
 void GetProcessMemoryUsage(ProcessInfo process_info[1024], uint32_t* process_count);
 
-void GetCpuUsage(ProcessInfo process_info[1024], uint32_t* process_count, BOOL first_run);
+void GetCpuUsage(Cpu cpu_info[1024], uint32_t* process_count, BOOL first_run);
 
 #endif  // SRC_PROCESS_H_

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -42,6 +42,11 @@ void Worker::HandleOKCallback() {
               Nan::New<v8::Number>(process_info[i].memory));
     }
 
+    if (CPU & *process_data_flags) {
+      Nan::Set(object, Nan::New<v8::String>("pcpu").ToLocalChecked(),
+              Nan::New<v8::Number>(process_info[i].cpu.pcpu));
+    }
+
     Nan::Set(result, i, Nan::New<v8::Value>(object));
   }
   v8::Local<v8::Value> argv[] = { result };

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -42,11 +42,6 @@ void Worker::HandleOKCallback() {
               Nan::New<v8::Number>(process_info[i].memory));
     }
 
-    if (CPU & *process_data_flags) {
-      Nan::Set(object, Nan::New<v8::String>("pcpu").ToLocalChecked(),
-              Nan::New<v8::Number>(process_info[i].cpu.pcpu));
-    }
-
     Nan::Set(result, i, Nan::New<v8::Value>(object));
   }
   v8::Local<v8::Value> argv[] = { result };

--- a/typings/windows-process-tree.d.ts
+++ b/typings/windows-process-tree.d.ts
@@ -13,6 +13,7 @@ declare module 'windows-process-tree' {
     pid: number;
     name: string;
     memory?: number;
+    cpu?: number;
     children: IProcessTreeNode[];
   }
 

--- a/typings/windows-process-tree.d.ts
+++ b/typings/windows-process-tree.d.ts
@@ -9,13 +9,27 @@ declare module 'windows-process-tree' {
     Memory = 1
   }
 
-  export interface IProcessTreeNode {
+  export interface IProcessInfo {
+    pid: number;
+    ppid: number;
+    name: string;
+    memory?: number;
+  }
+
+  export interface IProcessCpuInfo extends IProcessInfo {
+    cpu?: number;
+  }
+
+  export interface IProcessTreeNode  {
     pid: number;
     name: string;
     memory?: number;
-    cpu?: number;
     children: IProcessTreeNode[];
   }
 
   export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode) => void, flags?: ProcessDataFlag): void;
+
+  export function getProcessList(rootPid: number, callback: (processList: IProcessInfo[]) => void, flags?: ProcessDataFlag): void;
+
+  export function getProcessCpuUsage(processList: IProcessInfo[], callback: (processListWithCpu: IProcessCpuInfo[]) => void);
 }

--- a/typings/windows-process-tree.d.ts
+++ b/typings/windows-process-tree.d.ts
@@ -27,9 +27,28 @@ declare module 'windows-process-tree' {
     children: IProcessTreeNode[];
   }
 
+
+
+  /**
+   * Returns a tree of processes with the rootPid process as the root.
+   * @param {number} rootPid - The pid of the process that will be the root of the tree.
+   * @param {(tree: IProcessTreeNode) => void} callback - The callback to use with the returned list of processes.
+   * @param {ProcessDataFlag} flags - The flags for what process data should be included.
+   */
   export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode) => void, flags?: ProcessDataFlag): void;
 
+  /**
+   * Returns a list of processes containing the rootPid process and all of its descendants.
+   * @param {number} rootPid - The pid of the process of interest.
+   * @param {(processList: IProcessInfo[]) => void} callback - The callback to use with the returned set of processes.
+   * @param {ProcessDataFlag} flags - The flags for what process data should be included.
+   */
   export function getProcessList(rootPid: number, callback: (processList: IProcessInfo[]) => void, flags?: ProcessDataFlag): void;
 
+  /**
+   * Returns the list of processes annotated with cpu usage information.
+   * @param {processList: IProcessInfo[]} processList - The list of processes.
+   * @param {(processListWithCpu: IProcessCpuInfo[]) => void} callback - The callback to use with the returned list of processes.
+   */
   export function getProcessCpuUsage(processList: IProcessInfo[], callback: (processListWithCpu: IProcessCpuInfo[]) => void);
 }


### PR DESCRIPTION
Calculates the cpu usage of a process as the change in kernel + user time the process has used over the change in kernel + user time the system has used after sleeping for a second.

Currently this is being calculated for all processes when the flag is set instead of just the processes under rootId, as I was having trouble serializing the structure of cpu information back and forth between javascript and C++.