### PR TITLE
Increase commandLine length limit, #23

### DIFF
--- a/src/addon.cc
+++ b/src/addon.cc
@@ -84,6 +84,8 @@ void GetProcessCpuUsage(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::Local<v8::Value> argv[] = { result };
   callback->Call(1, argv);
+
+  delete[] cpu_info;
 }
 
 void Init(v8::Local<v8::Object> exports) {

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -9,9 +9,6 @@
 #include <cmath>
 
 void GetProcessList(const Nan::FunctionCallbackInfo<v8::Value>& args) {
-  ProcessInfo process_info[1024];
-  uint32_t process_count;
-
   if (args.Length() < 2) {
     Nan::ThrowTypeError("GetProcessList expects two arguments.");
     return;
@@ -28,8 +25,9 @@ void GetProcessList(const Nan::FunctionCallbackInfo<v8::Value>& args) {
   }
 
   Nan::Callback *callback = new Nan::Callback(v8::Local<v8::Function>::Cast(args[0]));
-  DWORD flags = (DWORD)args[1]->NumberValue();
-  Worker *worker = new Worker(process_info, &process_count, callback, &flags);
+  DWORD* flags = new DWORD;
+  *flags = (DWORD)args[1]->NumberValue();
+  Worker *worker = new Worker(callback, flags);
   Nan::AsyncQueueWorker(worker);
 }
 

--- a/src/process.h
+++ b/src/process.h
@@ -21,7 +21,7 @@ struct ProcessInfo {
   DWORD pid;
   DWORD ppid;
   DWORD memory; // Reported in bytes
-  TCHAR commandLine[512];
+  TCHAR commandLine[4096];
 };
 
 enum ProcessDataFlags {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -6,17 +6,18 @@
 #include "worker.h"
 
 Worker::Worker(
-    ProcessInfo* process_info,
-    uint32_t* process_count,
     Nan::Callback* callback,
     DWORD* process_data_flags) 
       : AsyncWorker(callback),
-        process_count(process_count),
-        process_info(process_info),
         process_data_flags(process_data_flags) {
+    process_info = new ProcessInfo[1024];
+    process_count = new uint32_t;
 }
 
 Worker::~Worker() {
+  delete[] process_info;
+  delete process_count;
+  delete process_data_flags;
 }
 
 void Worker::Execute() {

--- a/src/worker.h
+++ b/src/worker.h
@@ -11,14 +11,13 @@
 
 class Worker : public Nan::AsyncWorker {
  public:
-  Worker(ProcessInfo* process_info, uint32_t* process_count, 
-      Nan::Callback* callback, DWORD* process_data_flags);
+  Worker(Nan::Callback* callback, DWORD* process_data_flags);
   ~Worker();
 
   void Execute();
   void HandleOKCallback();
  private:
-  ProcessInfo *process_info;
+  ProcessInfo* process_info;
   uint32_t* process_count;
   DWORD* process_data_flags;
 };


### PR DESCRIPTION
The code that was causing problems was actually not the process_info array, but the allocation of the new V8 array being returned. When multiple calls to getProcessList were happening, the value process_count pointed to became a very large, garbage value, too big to create an array of that size. The memory was getting freed when getProcessList returned as the worker was running. I'm not entirely sure why everything worked so consistently before. I've now changed all of the data the worker uses to be dynamically allocated so that it's not freed until the worker is done.

Increases commandLine limit to 4096 chars