### PR TITLE
feat: define custom promisify implementations

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { promisify } from 'util';
+
 const native = require('../build/Release/windows_process_tree.node');
 import { IProcessInfo, IProcessTreeNode, IProcessCpuInfo } from 'windows-process-tree';
 
@@ -125,6 +127,16 @@ export function getProcessList(rootPid: number, callback: (processList: IProcess
   getRawProcessList(rootPid, processListRequestQueue, callback, filterProcessList, flags);
 }
 
+export namespace getProcessList {
+  // tslint:disable-next-line:variable-name
+  export const __promisify__ = (rootPid: number, flags?: ProcessDataFlag): Promise<IProcessInfo[]> => new Promise((resolve, reject) => {
+    const callback = (processList: IProcessInfo[] | undefined) => processList
+      ? resolve(processList)
+      : reject(new Error(`Could not find PID ${rootPid}`));
+    getProcessList(rootPid, callback, flags);
+  });
+}
+
 /**
  * Returns the list of processes annotated with cpu usage information
  * @param processList The list of processes
@@ -132,6 +144,18 @@ export function getProcessList(rootPid: number, callback: (processList: IProcess
  */
 export function getProcessCpuUsage(processList: IProcessInfo[], callback: (tree: IProcessCpuInfo[]) => void): void {
   native.getProcessCpuUsage(processList, callback);
+}
+
+export namespace getProcessCpuUsage {
+  // tslint:disable-next-line:variable-name
+  export const __promisify__ = (processList: IProcessInfo[]): Promise<IProcessCpuInfo[]> => new Promise((resolve, reject) => {
+    // NOTE: Currently this callback is *never* called with `undefined`, unlike the other functions which do PID lookups.
+    // The handling here is just for consistency and future-proofing.
+    const callback = (cpuInfos: IProcessCpuInfo[] | undefined) => cpuInfos
+      ? resolve(cpuInfos)
+      : reject(new Error('Failed to collect CPU info'));
+    getProcessCpuUsage(processList, callback);
+  });
 }
 
 /**
@@ -143,3 +167,18 @@ export function getProcessCpuUsage(processList: IProcessInfo[], callback: (tree:
 export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode | undefined) => void, flags?: ProcessDataFlag): void {
   getRawProcessList(rootPid, processTreeRequestQueue, callback, buildProcessTree, flags);
 }
+
+export namespace getProcessTree {
+  // tslint:disable-next-line:variable-name
+  export const __promisify__ = (rootPid: number, flags?: ProcessDataFlag): Promise<IProcessTreeNode> => new Promise((resolve, reject) => {
+    const callback = (tree: IProcessTreeNode | undefined) => tree
+      ? resolve(tree)
+      : reject(new Error(`Could not find PID ${rootPid}`));
+    getProcessTree(rootPid, callback, flags);
+  });
+}
+
+// Since symbol properties can't be declared via namespace merging, we just define __promisify__ that way and
+// and manually set the "modern" promisify symbol: https://github.com/microsoft/TypeScript/issues/36813
+[getProcessTree, getProcessList, getProcessCpuUsage].forEach(func =>
+  Object.defineProperty(func, promisify.custom, { enumerable: false, value: func.__promisify__ }));

--- a/lib/promises.ts
+++ b/lib/promises.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { promisify } from 'util';
+
+import * as wpc from './index';
+
+export { ProcessDataFlag } from './index';
+
+export const getProcessTree = promisify(wpc.getProcessTree);
+export const getProcessList = promisify(wpc.getProcessList);
+export const getProcessCpuUsage = promisify(wpc.getProcessCpuUsage);

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -6,10 +6,10 @@
 import * as assert from 'assert';
 import * as child_process from 'child_process';
 import * as path from 'path';
-import { promisify } from 'util';
 import { getProcessTree, getProcessList, getProcessCpuUsage, ProcessDataFlag, buildProcessTree, filterProcessList } from './index';
 import { Worker, isMainThread } from 'worker_threads';
 import { IProcessCpuInfo, IProcessInfo, IProcessTreeNode } from 'windows-process-tree';
+import * as promises from './promises';
 const native = require('../build/Release/windows_process_tree.node');
 
 function pollUntil(makePromise: () => Promise<boolean>, cb: () => void, interval: number, timeout: number): void {
@@ -111,8 +111,7 @@ describe('getProcessList', () => {
   });
 
   it('should work promisified', async () => {
-    const getProcessList$promisified = promisify(getProcessList);
-    const list: IProcessInfo[] = await getProcessList$promisified(process.pid);
+    const list: IProcessInfo[] = await promises.getProcessList(process.pid);
 
     assert.strictEqual(list.length, 1);
     const proc = list[0];
@@ -175,8 +174,7 @@ describe('getProcessCpuUsage', () => {
   });
 
   it('should work promisified', async () => {
-    const getProcessCpuUsage$promisified = promisify(getProcessCpuUsage);
-    const annotatedList: IProcessCpuInfo[] = await getProcessCpuUsage$promisified([{ pid: process.pid, ppid: process.ppid, name: 'node.exe' }]);
+    const annotatedList: IProcessCpuInfo[] = await promises.getProcessCpuUsage([{ pid: process.pid, ppid: process.ppid, name: 'node.exe' }]);
 
     assert.strictEqual(annotatedList.length, 1);
     const proc = annotatedList[0];
@@ -224,8 +222,7 @@ describe('getProcessTree', () => {
   });
 
   it('should work promisified', async () => {
-    const getProcessTree$promisified = promisify(getProcessTree);
-    const tree: IProcessTreeNode = await getProcessTree$promisified(process.pid);
+    const tree: IProcessTreeNode = await promises.getProcessTree(process.pid);
 
     assert.strictEqual(tree?.name, 'node.exe');
     assert.strictEqual(tree?.pid, process.pid);

--- a/typings/windows-process-tree.d.ts
+++ b/typings/windows-process-tree.d.ts
@@ -46,6 +46,10 @@ declare module 'windows-process-tree' {
    */
   export function getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode | undefined) => void, flags?: ProcessDataFlag): void;
 
+  namespace getProcessTree {
+    function __promisify__(rootPid: number, flags?: ProcessDataFlag): Promise<IProcessTreeNode>;
+  }
+
   /**
    * Returns a list of processes containing the rootPid process and all of its descendants.
    * @param rootPid - The pid of the process of interest.
@@ -54,10 +58,18 @@ declare module 'windows-process-tree' {
    */
   export function getProcessList(rootPid: number, callback: (processList: IProcessInfo[] | undefined) => void, flags?: ProcessDataFlag): void;
 
+  namespace getProcessList {
+    function __promisify__(rootPid: number, flags?: ProcessDataFlag): Promise<IProcessInfo[]>;
+  }
+
   /**
    * Returns the list of processes annotated with cpu usage information.
    * @param processList - The list of processes.
    * @param callback - The callback to use with the returned list of processes.
    */
   export function getProcessCpuUsage(processList: IProcessInfo[], callback: (processListWithCpu: IProcessCpuInfo[]) => void): void;
+
+  namespace getProcessCpuUsage {
+    function __promisify__(processList: IProcessInfo[]): Promise<IProcessCpuInfo[]>;
+  }
 }

--- a/typings/windows-process-tree/promises.d.ts
+++ b/typings/windows-process-tree/promises.d.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'windows-process-tree/promises' {
+  import {
+    IProcessCpuInfo,
+    IProcessInfo,
+    IProcessTreeNode,
+    ProcessDataFlag,
+  } from 'windows-process-tree';
+
+  export {
+    IProcessCpuInfo,
+    IProcessInfo,
+    IProcessTreeNode,
+    ProcessDataFlag,
+  } from 'windows-process-tree';
+
+  /**
+   * Returns a tree of processes with the rootPid process as the root.
+   * @param rootPid - The pid of the process that will be the root of the tree.
+   * @param flags - The flags for what process data should be included.
+   */
+  export function getProcessTree(rootPid: number, flags?: ProcessDataFlag): Promise<IProcessTreeNode>;
+
+  /**
+   * Returns a list of processes containing the rootPid process and all of its descendants.
+   * @param rootPid - The pid of the process of interest.
+   * @param flags - The flags for what process data should be included.
+   */
+  export function getProcessList(rootPid: number, flags?: ProcessDataFlag): Promise<IProcessInfo[]>;
+
+  /**
+   * Returns the list of processes annotated with cpu usage information.
+   * @param processList - The list of processes.
+   */
+  export function getProcessCpuUsage(processList: IProcessInfo[]): Promise<IProcessCpuInfo[]>;
+}


### PR DESCRIPTION
This defines properties on each of the exported asynchronous functions which allow them to work with Node's `promisify`.

The existing callbacks were incompatible by default, because they:
* are not given as the last arguments of those functions
* do not accept optional "error" as their first arguments

In other words, they are not "Node-style" callbacks.

This implementation chooses to reject promises rather than returning `undefined` on those errors as the callbacks do: presumably the `undefined` value is used simply because the existing callback format forgot to allow for an error parameter.

This defines both the modern `promisify.custom` symbol and the "old" `__promisify__` property, since the former isn't actually describable in TypeScript definitions yet, and the latter is still used in Node's definition files (e.g. for `child_process` functions). See:
* https://github.com/microsoft/TypeScript/issues/36813
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42154

Example usage:

```ts
import { promisify } from 'util';
import * as winProcTree from 'windows-process-tree';

const getProcessTree = promisify(winProcTree.getProcessTree);

async function doThings() {
  const myProcesses = await getProcessTree(process.pid);
  // etc.
}
```