### PR TITLE
minor internal request/queue type fixes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,7 +33,7 @@ const MAX_FILTER_DEPTH = 10;
  * @param processList The list of processes
  * @param maxDepth The maximum depth to search
  */
-export function buildProcessTree(rootPid: number, processList: IProcessInfo[] | undefined, maxDepth: number): IProcessTreeNode | undefined {
+export function buildProcessTree(rootPid: number, processList: IProcessInfo[] | undefined, maxDepth: number = MAX_FILTER_DEPTH): IProcessTreeNode | undefined {
   if (!processList) {
     return undefined;
   }
@@ -70,7 +70,7 @@ export function buildProcessTree(rootPid: number, processList: IProcessInfo[] | 
  * @param processList The list of all processes
  * @param maxDepth The maximum depth to search
  */
-export function filterProcessList(rootPid: number, processList: IProcessInfo[], maxDepth: number): IProcessInfo[] | undefined {
+export function filterProcessList(rootPid: number, processList: IProcessInfo[], maxDepth: number = MAX_FILTER_DEPTH): IProcessInfo[] | undefined {
   const rootIndex = processList.findIndex(v => v.pid === rootPid);
   if (rootIndex === -1) {
     return undefined;
@@ -97,7 +97,7 @@ function getRawProcessList(
   rootPid: number,
   queue: RequestQueue,
   callback: (processList: IProcessInfo[] | IProcessTreeNode | undefined) => void,
-  filter: (pid: number, processList: IProcessInfo[] | undefined, maxDepth: number) => IProcessInfo[] | IProcessTreeNode | undefined,
+  transform: (pid: number, processList: IProcessInfo[] | undefined) => IProcessInfo[] | IProcessTreeNode | undefined,
   flags?: ProcessDataFlag
 ): void {
   queue.push({ rootPid, callback });
@@ -110,7 +110,7 @@ function getRawProcessList(
     requestInProgress = true;
     native.getProcessList((processList: IProcessInfo[]) => {
       queue.forEach(r => {
-        r.callback(filter(r.rootPid, processList, MAX_FILTER_DEPTH));
+        r.callback(transform(r.rootPid, processList));
       });
       queue.length = 0;
       requestInProgress = false;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,10 +33,7 @@ const MAX_FILTER_DEPTH = 10;
  * @param processList The list of processes
  * @param maxDepth The maximum depth to search
  */
-export function buildProcessTree(rootPid: number, processList: IProcessInfo[] | undefined, maxDepth: number = MAX_FILTER_DEPTH): IProcessTreeNode | undefined {
-  if (!processList) {
-    return undefined;
-  }
+export function buildProcessTree(rootPid: number, processList: IProcessInfo[], maxDepth: number = MAX_FILTER_DEPTH): IProcessTreeNode | undefined {
   const rootIndex = processList.findIndex(v => v.pid === rootPid);
   if (rootIndex === -1) {
     return undefined;
@@ -97,7 +94,7 @@ function getRawProcessList(
   rootPid: number,
   queue: RequestQueue,
   callback: (processList: IProcessInfo[] | IProcessTreeNode | undefined) => void,
-  transform: (pid: number, processList: IProcessInfo[] | undefined) => IProcessInfo[] | IProcessTreeNode | undefined,
+  transform: (pid: number, processList: IProcessInfo[]) => IProcessInfo[] | IProcessTreeNode | undefined,
   flags?: ProcessDataFlag
 ): void {
   queue.push({ rootPid, callback });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,18 +12,18 @@ export enum ProcessDataFlag {
   CommandLine = 2
 }
 
-interface  IRequest {
-  callback: (processes: IProcessTreeNode | IProcessInfo[] | undefined) => void;
+interface  IRequest<T> {
+  callback: (result: T) => void;
   rootPid: number;
 }
 
-type RequestQueue = IRequest[];
+type RequestQueue<T> = IRequest<T>[];
 
 // requestInProgress is used for any function that uses CreateToolhelp32Snapshot, as multiple calls
 // to this cannot be done at the same time.
 let requestInProgress = false;
-const processListRequestQueue: RequestQueue = [];
-const processTreeRequestQueue: RequestQueue = [];
+const processListRequestQueue: RequestQueue<IProcessInfo[] | undefined> = [];
+const processTreeRequestQueue: RequestQueue<IProcessTreeNode | undefined> = [];
 
 const MAX_FILTER_DEPTH = 10;
 
@@ -90,11 +90,11 @@ export function filterProcessList(rootPid: number, processList: IProcessInfo[], 
   return children.reduce((prev, current) => prev.concat(current), [rootProcess]);
 }
 
-function getRawProcessList(
+function getRawProcessList<T>(
   rootPid: number,
-  queue: RequestQueue,
-  callback: (processList: IProcessInfo[] | IProcessTreeNode | undefined) => void,
-  transform: (pid: number, processList: IProcessInfo[]) => IProcessInfo[] | IProcessTreeNode | undefined,
+  queue: RequestQueue<T>,
+  callback: (result: T) => void,
+  transform: (pid: number, processList: IProcessInfo[]) => T,
   flags?: ProcessDataFlag
 ): void {
   queue.push({ rootPid, callback });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -94,16 +94,13 @@ export function filterProcessList(rootPid: number, processList: IProcessInfo[], 
 }
 
 function getRawProcessList(
-  pid: number,
+  rootPid: number,
   queue: RequestQueue,
   callback: (processList: IProcessInfo[] | IProcessTreeNode | undefined) => void,
   filter: (pid: number, processList: IProcessInfo[] | undefined, maxDepth: number) => IProcessInfo[] | IProcessTreeNode | undefined,
   flags?: ProcessDataFlag
 ): void {
-  queue.push({
-    callback: callback,
-    rootPid: pid
-  });
+  queue.push({ rootPid, callback });
 
   // Only make a new request if there is not currently a request in progress.
   // This prevents too many requests from being made, there is also a crash that


### PR DESCRIPTION
Minor (internal) type fixes. In current `main`, the types incorrect: for example `getRawProcessList` specifies a callback that can accept _either_ `IProcessInfo[] | IProcessTreeNode`, which none of them do.

This straightens it out, along with some related minor cleanups.