### PR TITLE
Normalize linker args

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,7 @@
             "src/process_commandline.cc"
           ],
           "include_dirs": [],
-          "libraries": [ 'psapi.lib' ],
+          "libraries": [ '-lpsapi.lib' ],
           "msvs_configuration_attributes": {
             "SpectreMitigation": "Spectre"
           },


### PR DESCRIPTION
The `libraries` entry is meant to contain linker args prefixed with `-l`. See i.e. https://github.com/nodejs/node-gyp/blob/0e656322c1e94041331ab3b01bf66c2ef9bd6ead/addon.gypi#L170-L182

I ran into this experimenting with Makefile backend for gyp in a cross-compiler env.