### PR TITLE
fix: preserve Unicode in process command lines

### DIFF
--- a/lib/test.ts
+++ b/lib/test.ts
@@ -178,6 +178,41 @@ if (isWindows) {
       }, ProcessDataFlag.CommandLine);
     });
 
+    it('should preserve Unicode characters in command line', async () => {
+      const marker = 'Türkçe-Привет-你好';
+      const child = child_process.spawn(
+        process.execPath,
+        ['-e', 'setInterval(() => {}, 10000)', marker],
+        { windowsHide: true }
+      );
+      cps.push(child);
+
+      assert.ok(child.pid, 'Failed to start the test process');
+      const childPid = child.pid;
+
+      await new Promise<void>((resolve, reject) => {
+        const deadline = Date.now() + 2000;
+
+        const poll = () => {
+          getProcessList(childPid, (list) => {
+            if (list?.some(processInfo => processInfo.pid === childPid && processInfo.commandLine?.includes(marker))) {
+              resolve();
+              return;
+            }
+
+            if (Date.now() >= deadline) {
+              reject(new Error(`Timed out waiting for Unicode command line marker: ${marker}`));
+              return;
+            }
+
+            setTimeout(poll, 20);
+          }, ProcessDataFlag.CommandLine);
+        };
+
+        poll();
+      });
+    });
+
     it('should return a list containing this process\'s child processes', done => {
       cps.push(child_process.spawn('cmd.exe'));
       pollUntil(() => {

--- a/src/process_commandline.cc
+++ b/src/process_commandline.cc
@@ -46,11 +46,11 @@ bool GetProcessCommandLine(ProcessInfo& process_info) {
           buffer.resize(process_parameters.CommandLine.Length / sizeof(wchar_t));
           if (ReadProcessMemory(hProcess, process_parameters.CommandLine.Buffer, &buffer[0], process_parameters.CommandLine.Length, nullptr)) {
             int wide_length = static_cast<int>(buffer.length());
-            int charcount = WideCharToMultiByte(CP_ACP, 0, buffer.data(), wide_length,
+            int charcount = WideCharToMultiByte(CP_UTF8, 0, buffer.data(), wide_length,
                                       NULL, 0, NULL, NULL);
             if (charcount) {
               process_info.commandLine.resize(static_cast<size_t>(charcount));
-              WideCharToMultiByte(CP_ACP, 0, buffer.data(), wide_length,
+              WideCharToMultiByte(CP_UTF8, 0, buffer.data(), wide_length,
                                   &process_info.commandLine[0], charcount,
                                   NULL, NULL);
             }


### PR DESCRIPTION
## Summary

  Fixes Unicode handling for process command lines returned by `getProcessList`.

  Windows exposes process command lines as UTF-16. The native code previously
  converted them with the active Windows ANSI code page (`CP_ACP`), but the
  resulting `std::string` is passed to N-API as UTF-8. Characters outside the
  active code page could therefore be replaced or decoded incorrectly.

  This change:

  - converts command lines from UTF-16 to UTF-8 using `CP_UTF8`
  - adds a regression test covering Turkish, Cyrillic, and Chinese characters

  ## Testing

  - `npm run compile`
  - `npm run lint`
  - `git diff --check`
  - `npm test` 

  Fixes #76